### PR TITLE
SMA-477: dont try to call the eod api for additional symbols if they …

### DIFF
--- a/src/Drivers/EodApi.php
+++ b/src/Drivers/EodApi.php
@@ -68,19 +68,29 @@ class EodApi implements StockPricesApiDriver
     {
         $symbol  = array_shift($symbols);
         $symbols = implode(',', $symbols);
+        $noAdditionalSymbols = empty($symbols);
 
         $url = self::BASE_URL . 'api/real-time/' . $symbol;
 
         Log::info('Calling EOD API on ' . $url . ' - symbols: ' . $symbols);
 
         try {
-            $response = $this->guzzle->get($url, [
-                'query' => [
-                    'api_token' => $this->apiKey,
-                    'fmt'       => 'json',
-                    's'         => $symbols
-                ]
-            ]);
+            if ($noAdditionalSymbols) {
+                $response = $this->guzzle->get($url, [
+                    'query' => [
+                        'api_token' => $this->apiKey,
+                        'fmt'       => 'json',
+                    ]
+                ]);
+            } else {
+                $response = $this->guzzle->get($url, [
+                    'query' => [
+                        'api_token' => $this->apiKey,
+                        'fmt'       => 'json',
+                        's'         => $symbols
+                    ]
+                ]);
+            }
         } catch (RequestException $e) {
             $this->handleError($e);
         }


### PR DESCRIPTION
Als het aantal stocks in SM zo uitkwam dat de laatste chunk maar 1 stock had, werd er een lege symbols array naar EOD gestuurd omdat die ene stock uit de array gehaald wordt door array_shift. Hierdoor kwam er een verkeerde response van de EOD API. Nu worden er alleen maar meer symbols naar EOD gestuurd als de array niet leeg is